### PR TITLE
Records can be declared with a type/protocol specification for type safety.

### DIFF
--- a/doc/record.txt
+++ b/doc/record.txt
@@ -20,10 +20,27 @@
 #   ```ruby
 #   Functional::Record.new("Customer", :name, :address) #=> Functional::Record::Customer
 #   ```
-#   
-#   **NOTE:** The `new` method of `Record` does not accept a block the way Ruby's `Struct`
-#   does. The block passed to the `new` method of `Record` is used to set mandatory fields
-#   and default values (see below). It is *not* used for additional class declarations.
+#
+#   ### Type Specification
+#
+#   Unlike a Ruby `Struct`, a `Record` may be declared with a type/protocol
+#   specification. In this case, all data members are checked against the
+#   specification whenever a new record is created. Declaring a `Record` with a
+#   type specification is similar to declaring a normal `Record`, except that
+#   the field list is given as a hash with field names as the keys and a class or
+#   protocol as the values.
+#
+#   ```ruby
+#   Functional::SpecifyProtocol(:Name) do
+#     attr_reader :first
+#     attr_reader :middle
+#     attr_reader :last
+#   end
+#
+#   TypedCustomer = Functional::Record.new(name: :Name, address: String) #=> TypedCustomer
+#
+#   Functional::Record.new("TypedCustomer", name: :Name, address: String) #=> Functional::Record::TypedCustomer
+#   ```
 #   
 #   ### Construction
 #   
@@ -44,6 +61,28 @@
 #   
 #   Functional::Record::Customer.new(name: 'Dave', address: '123 Main')
 #    #=> #<record Functional::Record::Customer :name=>"Dave", :address=>"123 Main">
+#   ```
+#
+#   When a record is defined with a type/protocol specification, the values of
+#   all non-nil data members are checked against the specification. Any data
+#   value that is not of the given type or does not satisfy the given protocol
+#   will cause an exception to be raised:
+#
+#   ```ruby
+#   class Name
+#     attr_reader :first, :middle, :last
+#     def initialize(first, middle, last)
+#       @first = first
+#       @middle = middle
+#       @last = last
+#     end
+#   end
+#   
+#   name = Name.new('Douglas', nil, 'Adams') #=> #<Name:0x007fc8b951a278 ...
+#   TypedCustomer.new(name: name, address: '123 Main') #=> #<record TypedCustomer :name=>#<Name:0x007f914cce05b0 ...
+#   
+#   TypedCustomer.new(name: 'Douglas Adams', address: '123 Main') #=> ArgumentError: 'name' must stasify the protocol :Name
+#   TypedCustomer.new(name: name, address: 42) #=> ArgumentError: 'address' must be of type String
 #   ```
 #   
 #   ### Default Values
@@ -198,10 +237,13 @@
 #   and [C#](http://msdn.microsoft.com/en-us/library/ah19swz4.aspx),
 #   just to name a few. Immutable records exist primarily in functional languages
 #   like [Haskell](http://en.wikibooks.org/wiki/Haskell/More_on_datatypes#Named_Fields_.28Record_Syntax.29),
-#   Clojure, and Erlang. The latter two are the main influences for this implementation.
+#   Clojure, and Erlang. The inspiration for declaring records with a type
+#   specification is taken from [PureScript](http://www.purescript.org/), a
+#   compile-to-JavaScript language inspired by Haskell.
 #   
 #   * [Ruby Struct](http://www.ruby-doc.org/core-2.1.2/Struct.html)
 #   * [Clojure Datatypes](http://clojure.org/datatypes)
 #   * [Clojure *defrecord* macro](http://clojure.github.io/clojure/clojure.core-api.html#clojure.core/defrecord)
 #   * [Erlang Records (Reference)](http://www.erlang.org/doc/reference_manual/records.html)
 #   * [Erlang Records (Examples)](http://www.erlang.org/doc/programming_examples/records.html)
+#   * [PureScript Records](http://docs.purescript.org/en/latest/types.html#records)

--- a/spec/functional/record_spec.rb
+++ b/spec/functional/record_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require_relative 'abstract_struct_shared'
+require 'securerandom'
 
 module Functional
 
@@ -16,12 +17,49 @@ module Functional
 
     context 'definition' do
 
-      it 'registers the new class with Record when given a string name' do
-        Record.new('Foo', :foo, :bar, :baz)
-        expect(defined?(Record::Foo)).to eq 'constant'
+      it 'does not register a new class when no name is given' do
+        Record.new(:foo, :bar, :baz)
+        expect(defined?(Record::Foo)).to be_falsey
       end
 
-      it 'default all fields values to nil' do
+      it 'creates a new class when given an array of field names' do
+        clazz = Record.new(:foo, :bar, :baz)
+        expect(clazz).to be_a Class
+        expect(clazz.ancestors).to include(Functional::AbstractStruct)
+      end
+
+      it 'registers the new class with Record when given a string name and an array' do
+        Record.new('Bar', :foo, :bar, :baz)
+        expect(defined?(Record::Bar)).to eq 'constant'
+      end
+
+      it 'creates a new class when given a hash of field names and types/protocols' do
+        clazz = Record.new(foo: String, bar: String, baz: String)
+        expect(clazz).to be_a Class
+        expect(clazz.ancestors).to include(Functional::AbstractStruct)
+      end
+
+      it 'registers the new class with Record when given a string name and a hash' do
+        Record.new('Boom', foo: String, bar: String, baz: String)
+        expect(defined?(Record::Boom)).to eq 'constant'
+      end
+
+      it 'raises an exception when given a hash with an invalid type/protocol' do
+        expect {
+          Record.new(foo: 'String', bar: String, baz: String)
+        }.to raise_error(ArgumentError)
+      end
+
+      it 'raises an exception when given an invalid definition' do
+        expect {
+          Record.new(:foo, bar: String, baz: String)
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'initialization' do
+
+      it 'sets all fields values to nil' do
         fields = [:foo, :bar, :baz]
         clazz = Record.new(*fields)
 
@@ -41,74 +79,156 @@ module Functional
         expect(record.baz).to eq 3
       end
 
-      it 'defaults fields to values given during class creation' do
-        clazz = Record.new(:foo, :bar, :baz) do
-          default :foo, 42
-          default :bar, 'w00t!'
+      context 'with default values' do
+
+        it 'defaults fields to values given during class creation' do
+          clazz = Record.new(:foo, :bar, :baz) do
+            default :foo, 42
+            default :bar, 'w00t!'
+          end
+
+          record = clazz.new
+          expect(record.foo).to eq 42
+          expect(record.bar).to eq 'w00t!'
+          expect(record.baz).to be_nil
         end
 
-        record = clazz.new
-        expect(record.foo).to eq 42
-        expect(record.bar).to eq 'w00t!'
-        expect(record.baz).to be_nil
+        it 'overrides default values with values provided at object construction' do
+          clazz = Record.new(:foo, :bar, :baz) do
+            default :foo, 42
+            default :bar, 'w00t!'
+            default :baz, :bogus
+          end
+
+          record = clazz.new(foo: 1, bar: 2)
+
+          expect(record.foo).to eq 1
+          expect(record.bar).to eq 2
+          expect(record.baz).to eq :bogus
+        end
+
+        it 'duplicates default values when assigning to a new object' do
+          original = 'Foo'
+          clazz = Record.new(:foo, :bar, :baz) do
+            default :foo, original
+          end
+
+          record = clazz.new
+          expect(record.foo).to eq original
+          expect(record.foo.object_id).to_not eql original.object_id
+        end
+
+        it 'does not conflate defaults across record classes' do
+          clazz_foo = Record.new(:foo, :bar, :baz) do
+            default :foo, 42
+          end
+
+          clazz_matz = Record.new(:foo, :bar, :baz) do
+            default :foo, 'Matsumoto'
+          end
+
+          expect(clazz_foo.new.foo).to eq 42
+          expect(clazz_matz.new.foo).to eq 'Matsumoto'
+        end
       end
 
-      it 'overrides default values with values provided at object construction' do
-        clazz = Record.new(:foo, :bar, :baz) do
-          default :foo, 42
-          default :bar, 'w00t!'
-          default :baz, :bogus
+      context 'with mandatory fields' do
+
+        it 'raises an exception when values for requred field are not provided' do
+          clazz = Record.new(:foo, :bar, :baz) do
+            mandatory :foo
+          end
+
+          expect {
+            clazz.new(bar: 1)
+          }.to raise_exception(ArgumentError)
         end
 
-        record = clazz.new(foo: 1, bar: 2)
+        it 'raises an exception when required values are nil' do
+          clazz = Record.new(:foo, :bar, :baz) do
+            mandatory :foo
+          end
 
-        expect(record.foo).to eq 1
-        expect(record.bar).to eq 2
-        expect(record.baz).to eq :bogus
+          expect {
+            clazz.new(foo: nil, bar: 1)
+          }.to raise_exception(ArgumentError)
+        end
+
+        it 'allows multiple required fields to be specified together' do
+          clazz = Record.new(:foo, :bar, :baz) do
+            mandatory :foo, :bar, :baz
+          end
+
+          expect {
+            clazz.new(foo: 1, bar: 2)
+          }.to raise_exception(ArgumentError)
+
+          expect {
+            clazz.new(bar: 2, baz: 3)
+          }.to raise_exception(ArgumentError)
+
+          expect {
+            clazz.new(foo: 1, bar: 2, baz: 3)
+          }.to_not raise_exception
+        end
+
+        it 'does not conflate default values across record classes' do
+          clazz_foo = Record.new(:foo, :bar, :baz) do
+            mandatory :foo
+          end
+
+          clazz_baz = Record.new(:foo, :bar, :baz) do
+            mandatory :baz
+          end
+
+          expect {
+            clazz_foo.new(foo: 42)
+          }.to_not raise_error
+
+          expect {
+            clazz_baz.new(baz: 42)
+          }.to_not raise_error
+        end
       end
 
-      it 'duplicates default values when assigning to a new object' do
-        original = 'Foo'
-        clazz = Record.new(:foo, :bar, :baz) do
-          default :foo, original
+      context 'with field type specification' do
+
+        let(:type_safe_definition) do
+          {foo: String, bar: Fixnum, baz: protocol}
         end
 
-        record = clazz.new
-        expect(record.foo).to eq original
-        expect(record.foo.object_id).to_not eql original.object_id
-      end
+        let(:protocol){ SecureRandom.uuid.to_sym }
 
-      it 'does not conflate defaults across record classes' do
-        clazz_foo = Record.new(:foo, :bar, :baz) do
-          default :foo, 42
+        let(:clazz_with_protocol) do
+          Class.new do
+            def foo() nil end
+          end
         end
 
-        clazz_matz = Record.new(:foo, :bar, :baz) do
-          default :foo, 'Matsumoto'
+        let(:record_clazz) do
+          Record.new(type_safe_definition)
         end
 
-        expect(clazz_foo.new.foo).to eq 42
-        expect(clazz_matz.new.foo).to eq 'Matsumoto'
-      end
-
-      it 'raises an exception when values for requred field are not provided' do
-        clazz = Record.new(:foo, :bar, :baz) do
-          mandatory :foo
+        before(:each) do
+          Functional::SpecifyProtocol(protocol){ instance_method(:foo) }
         end
 
-        expect {
-          clazz.new(bar: 1)
-        }.to raise_exception(ArgumentError)
-      end
-
-      it 'raises an exception when required values are nil' do
-        clazz = Record.new(:foo, :bar, :baz) do
-          mandatory :foo
+        it 'raises an exception for a value with an invalid type' do
+          expect {
+            record_clazz.new(foo: 'foo', bar: 'bar', baz: clazz_with_protocol.new)
+          }.to raise_error(ArgumentError)
         end
 
-        expect {
-          clazz.new(foo: nil, bar: 1)
-        }.to raise_exception(ArgumentError)
+        it 'raises an exception for a value that does not satisfy a protocol' do
+          expect {
+            record_clazz.new(foo: 'foo', bar: 42, baz: 'baz')
+          }.to raise_error(ArgumentError)
+        end
+
+        it 'creates the object when all values match the appropriate types and protocols' do
+          record = record_clazz.new(foo: 'foo', bar: 42, baz: clazz_with_protocol.new)
+          expect(record).to be_a record_clazz
+        end
       end
 
       it 'allows a field to be required and have a default value' do
@@ -124,24 +244,6 @@ module Functional
         expect(clazz.new.foo).to eq 42
       end
 
-      it 'allows multiple required fields to be specified together' do
-        clazz = Record.new(:foo, :bar, :baz) do
-          mandatory :foo, :bar, :baz
-        end
-
-        expect {
-          clazz.new(foo: 1, bar: 2)
-        }.to raise_exception(ArgumentError)
-
-        expect {
-          clazz.new(bar: 2, baz: 3)
-        }.to raise_exception(ArgumentError)
-
-        expect {
-          clazz.new(foo: 1, bar: 2, baz: 3)
-        }.to_not raise_exception
-      end
-
       it 'raises an exception if the default value for a require field is nil' do
         clazz = Record.new(:foo, :bar, :baz) do
           mandatory :foo
@@ -151,24 +253,6 @@ module Functional
         expect {
           clazz.new
         }.to raise_exception(ArgumentError)
-      end
-
-      it 'does not conflate default values across record classes' do
-        clazz_foo = Record.new(:foo, :bar, :baz) do
-          mandatory :foo
-        end
-
-        clazz_baz = Record.new(:foo, :bar, :baz) do
-          mandatory :baz
-        end
-
-        expect {
-          clazz_foo.new(foo: 42)
-        }.to_not raise_error
-
-        expect {
-          clazz_baz.new(baz: 42)
-        }.to_not raise_error
       end
     end
 


### PR DESCRIPTION
Unlike a Ruby `Struct`, a `Record` may be declared with a type/protocol specification. In this case, all data members are checked against the specification whenever a new record is created. Declaring a `Record` with a type specification is similar to declaring a normal `Record`, except that the field list is given as a hash with field names as the keys and a class or protocol as the values.

``` ruby
Functional::SpecifyProtocol(:Name) do
  attr_reader :first
  attr_reader :middle
  attr_reader :last
end

TypedCustomer = Functional::Record.new(name: :Name, address: String) #=> TypedCustomer

Functional::Record.new("TypedCustomer", name: :Name, address: String) #=> Functional::Record::TypedCustomer
```
