### PR TITLE
Remove require spec helper

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--format progress

--- a/spec/functional/complex_pattern_matching_spec.rb
+++ b/spec/functional/complex_pattern_matching_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'ostruct'
 
 class Bar
@@ -194,7 +193,7 @@ describe 'complex pattern matching' do
 
     specify { expect(Fizzbuzz.new.who(5)).to eq 15 }
     specify { expect(Fizzbuzz.new.who()).to eq 0 }
-    specify { 
+    specify {
       expect {
         Fizzbuzz.new.who('Jerry', 'secret middle name', "D'Antonio")
       }.to raise_error(NoMethodError)

--- a/spec/functional/configuration_spec.rb
+++ b/spec/functional/configuration_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Functional
 
   context Configuration do

--- a/spec/functional/delay_spec.rb
+++ b/spec/functional/delay_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Functional
 
   describe Delay do

--- a/spec/functional/either_spec.rb
+++ b/spec/functional/either_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'abstract_struct_shared'
 
 module Functional

--- a/spec/functional/final_struct_spec.rb
+++ b/spec/functional/final_struct_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'ostruct'
 
 module Functional

--- a/spec/functional/final_var_spec.rb
+++ b/spec/functional/final_var_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Functional
 
   describe FinalVar do

--- a/spec/functional/memo_spec.rb
+++ b/spec/functional/memo_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Functional
 
   describe Memo do

--- a/spec/functional/option_spec.rb
+++ b/spec/functional/option_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'abstract_struct_shared'
 require 'securerandom'
 

--- a/spec/functional/pattern_matching_spec.rb
+++ b/spec/functional/pattern_matching_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'ostruct'
 
 module Functional

--- a/spec/functional/protocol_info_spec.rb
+++ b/spec/functional/protocol_info_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Functional
 
   describe ProtocolInfo do

--- a/spec/functional/protocol_spec.rb
+++ b/spec/functional/protocol_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'protocol specification' do
 
   before(:each) do

--- a/spec/functional/record_spec.rb
+++ b/spec/functional/record_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'abstract_struct_shared'
 require 'securerandom'
 

--- a/spec/functional/tuple_spec.rb
+++ b/spec/functional/tuple_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'rspec/expectations'
 
 RSpec::Matchers.define :be_a_different_tuple_than do |expected|

--- a/spec/functional/type_check_spec.rb
+++ b/spec/functional/type_check_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Functional
 
   describe TypeCheck do

--- a/spec/functional/union_spec.rb
+++ b/spec/functional/union_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'abstract_struct_shared'
 
 module Functional

--- a/spec/functional/value_struct_spec.rb
+++ b/spec/functional/value_struct_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'ostruct'
 
 module Functional


### PR DESCRIPTION
This PR adds the `Rspec` dot file, allowing you to omit the `require
'spec_helper'` line in the beginning of spec files.

This PR also sets the default output format of Rspec to `progress`.