### PR TITLE
use example class in protocol spec assertion

### DIFF
--- a/spec/functional/protocol_spec.rb
+++ b/spec/functional/protocol_spec.rb
@@ -94,7 +94,7 @@ describe 'protocol specification' do
         end
 
         expect(
-          Functional::Protocol.Satisfy?('object', :foo)
+          Functional::Protocol.Satisfy?(clazz.new, :foo)
         ).to be false
       end
 


### PR DESCRIPTION
I believe the intention here was to assert that the example class matched the protocol specified (instead of a String object).

This change only affects the "returns false on failure" protocol spec test.